### PR TITLE
fix tailing ifs following quotes

### DIFF
--- a/plugin/textobj/rubyblock.vim
+++ b/plugin/textobj/rubyblock.vim
@@ -16,7 +16,7 @@ let s:comment_escape = '\v^[^#]*'
 let s:block_openers = '\zs(<def>|<if>|<do>|<module>|<class>)'
 let s:start_pattern = s:comment_escape . s:block_openers
 let s:end_pattern = s:comment_escape . '\zs<end>'
-let s:skip_pattern = 'getline(".") =~ "\\w\\s\\+if"'
+let s:skip_pattern = 'getline(".") =~ "\\w\\s\\.*+if"'
 
 function! s:select_a()
   let s:flags = 'W'


### PR DESCRIPTION
Hi Drew

Thanks for your time yesterday - lots of new vim toys to play with.

As I mentioned in the class, trailing ifs can sometimes break this plugin.  It looks like the problem only occurs when there are quotes before the if, eg:

``` ruby
class Foo

  def bar
    puts 'hello' if baz
  end

end
```

If you put the cursor on or after the 'if' keyword and press 'var' it works as expected.  If you put the cursor on or before the word hello and press 'var', it's borked.

So I guess the problem is with your skip_pattern regexp.  I tweaked it a bit to match any char (not just word chars) before the if, and that seems to do the trick.

Please review.  And thanks for the excellent scotch!
