### PR TITLE
Add vim-text-obj-user dependency for NeoBundle.

### DIFF
--- a/plugin/textobj/rubyblock.vim
+++ b/plugin/textobj/rubyblock.vim
@@ -1,9 +1,9 @@
-if exists(':NeoBundleDepends')
-  NeoBundleDepends 'kana/vim-textobj-user'
-endif
-
 if exists('g:loaded_textobj_rubyblock')  "{{{1
   finish
+endif
+
+if exists(':NeoBundleDepends')
+  NeoBundleDepends 'kana/vim-textobj-user'
 endif
 
 " Interface  "{{{1


### PR DESCRIPTION
Tells NeoBundle that this plugin depends on  `kana/vim-textobj-user`, installing it where necessary.
