### PR TITLE
Remove NeoBundle check

### DIFF
--- a/plugin/textobj/rubyblock.vim
+++ b/plugin/textobj/rubyblock.vim
@@ -2,10 +2,6 @@ if exists('g:loaded_textobj_rubyblock')  "{{{1
   finish
 endif
 
-if exists(':NeoBundleDepends')
-  NeoBundleDepends 'kana/vim-textobj-user'
-endif
-
 " Interface  "{{{1
 call textobj#user#plugin('rubyblock', {
 \      '-': {


### PR DESCRIPTION
Well that was short-lived.

`:NeoBundleDepends` [was removed](https://github.com/Shougo/neobundle.vim/commit/7e644cdac22752345eca21d0cd54930a6cedc74a), leaving me uncertain as to how to declare a dependency within a plugin. I think we may need to fork [neobundle-vim-recipes](https://github.com/Shougo/neobundle-vim-recipes) and add a recipe instead, but I'm currently unable to get recipe functionality working (Windows box, curl issues, etc.).
