### PR TITLE
add the rest of the block opener keywords

### DIFF
--- a/plugin/textobj/rubyblock.vim
+++ b/plugin/textobj/rubyblock.vim
@@ -13,7 +13,8 @@ call textobj#user#plugin('rubyblock', {
 
 " Misc.  "{{{1
 let s:comment_escape = '\v^[^#]*'
-let s:block_openers = '\zs(<def>|<if>|<do>|<module>|<class>)'
+let s:block_openers = '\zs(<def>|<if>|<unless>|<do>|<module>|<class>|<case>'
+let s:block_openers .= '|<for>|<while>|<until>|<begin>)'
 let s:start_pattern = s:comment_escape . s:block_openers
 let s:end_pattern = s:comment_escape . '\zs<end>'
 let s:skip_pattern = 'getline(".") =~ "\\v\\S\\s<(if|unless)>\\s\\S"'

--- a/t/examples.rb
+++ b/t/examples.rb
@@ -65,3 +65,19 @@ def hello
   bar
 end
 
+def method_with_while
+  var1 = 1
+  i = 0
+  while i < 10
+    i += 1
+  end
+  var2 = 2
+end
+
+def method_with_unless
+  var1 = 1
+  unless condition
+    puts 'foo'
+  end
+  var2 = 2
+end

--- a/t/rubyblock_test.vim
+++ b/t/rubyblock_test.vim
@@ -86,6 +86,23 @@ describe '<Plug>(textobj-rubyblock-a)'
 
 end
 
+describe 'nested while and unless blocks'
+
+  before
+    silent tabnew t/examples.rb
+  end
+
+  after
+    silent tabclose
+  end
+
+  it 'ignores nested while and unless blocks'
+    Expect SelectAroundFrom(69, '^') ==# [69, 68, 75]
+    Expect SelectAroundFrom(78, '^') ==# [78, 77, 83]
+  end
+
+end
+
 describe '<Plug>(textobj-rubyblock-i)'
 
   before


### PR DESCRIPTION
Some of ruby's block opener keywords were missing which caused a few different issues as outlined by the tests I added which do not pass with the old s:block_openers string.